### PR TITLE
Set readlinkat as NA for Windows

### DIFF
--- a/src/posixat_stubs.c
+++ b/src/posixat_stubs.c
@@ -5,6 +5,7 @@
 
 NA(at_fdcwd);
 NA(fstatat);
+NA(readlinkat);
 NA(fdopendir);
 
 CAMLprim value shexp_fd_info(value fd)


### PR DESCRIPTION
Fixes:

```
PS Y:\source\shexp> opam exec --switch Y:\source\dksdk-type -- dune utop process-lib/src
File "_none_", line 1:
Error: Error while linking Y:\source\dksdk-type\_opam\lib\posixat\posixat.cma(Posixat):
       The external function `shexp_readlinkat' is not available
```

### Testing

Done at https://github.com/janestreet/shexp/pull/15